### PR TITLE
fix(joystick): requested thrust is not fully acutuated

### DIFF
--- a/template_joystick_control/template_joystick_control/task_basin.py
+++ b/template_joystick_control/template_joystick_control/task_basin.py
@@ -15,6 +15,9 @@ def joystick_basin(
     comamnded directions that are interpreted with respect to basin / pool.
     If heading is 0 the effect will be the same as if user called joystick_body.
     """
+    # double the vaule in surge and sway to compensate for the two azimuth thrusters.
+    # However this should probably be rewritten to something that normalizes the
+    # output given the joy actuation.
     surge_command = 2 * joystick.axes[axes.LEFT_Y]
     sway_command = 2 * joystick.axes[axes.LEFT_X]
     yaw_command = joystick.axes[axes.RIGHT_X]

--- a/template_joystick_control/template_joystick_control/task_basin.py
+++ b/template_joystick_control/template_joystick_control/task_basin.py
@@ -15,9 +15,9 @@ def joystick_basin(
     comamnded directions that are interpreted with respect to basin / pool.
     If heading is 0 the effect will be the same as if user called joystick_body.
     """
+    surge_command = 2 * joystick.axes[axes.LEFT_Y]
+    sway_command = 2 * joystick.axes[axes.LEFT_X]
     yaw_command = joystick.axes[axes.RIGHT_X]
-    surge_command = joystick.axes[axes.LEFT_Y]
-    sway_command = joystick.axes[axes.LEFT_X]
 
     tau = inv_rotate(
         heading) @ np.array([surge_command, sway_command, yaw_command], dtype=float).T


### PR DESCRIPTION
Without this patch the produced command is not fully utilized. Rather the produced command is at most 0.5. This could mean that the command is being split across two azimuth thrusters or that there is some other problem. Since tau symbolizes requested force in newton we then should modify multiply joy with this scaling factor such that both thrusters are taken into accout. I don't like this aproach because it's not generic enough and leaves two random scalars in the code.