### PR TITLE
refactor(joystick): swap dependency between basin and body

### DIFF
--- a/template_joystick_control/template_joystick_control/mapping.py
+++ b/template_joystick_control/template_joystick_control/mapping.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 
 # TOOD: check if frozen=True can be used
-@dataclass(slots=True, init=False)
+@dataclass(slots=True, init=True)
 class JoystickButtons:
     CROSS: int = 0
     CIRCLE: int = 1

--- a/template_joystick_control/template_joystick_control/task_basin.py
+++ b/template_joystick_control/template_joystick_control/task_basin.py
@@ -15,5 +15,5 @@ def joystick_basin(
     return [`surge` `sway` `yaw`] commands relative to `heading`
     """
 
-    offset = 0
+    offset = -pi/2
     return joystick_body(joystick, axes, heading + offset)

--- a/template_joystick_control/template_joystick_control/task_basin.py
+++ b/template_joystick_control/template_joystick_control/task_basin.py
@@ -1,9 +1,9 @@
+from numpy import pi
 from numpy.typing import ArrayLike
 from template_joystick_control.mapping import JoystickAxes
+from template_joystick_control.task_body import joystick_body
 from template_joystick_control.topic import Topic
-from template_joystick_control.kinematics import inv_rotate
 from typing import Tuple, Literal
-import numpy as np
 import sensor_msgs.msg
 
 
@@ -12,14 +12,8 @@ def joystick_basin(
         axes: JoystickAxes,
         heading: float) -> Tuple[ArrayLike, Literal[Topic.joystick]]:
     """
-    comamnded directions that are interpreted with respect to basin / pool.
-    If heading is 0 the effect will be the same as if user called joystick_body.
+    return [`surge` `sway` `yaw`] commands relative to `heading`
     """
-    yaw_command = joystick.axes[axes.RIGHT_X]
-    surge_command = joystick.axes[axes.LEFT_Y]
-    sway_command = joystick.axes[axes.LEFT_X]
 
-    tau = inv_rotate(
-        heading) @ np.array([surge_command, sway_command, yaw_command], dtype=float).T
-
-    return np.array(tau, dtype=float).T, Topic.joystick
+    offset = 0
+    return joystick_body(joystick, axes, heading + offset)

--- a/template_joystick_control/template_joystick_control/task_body.py
+++ b/template_joystick_control/template_joystick_control/task_body.py
@@ -1,15 +1,23 @@
 from numpy.typing import ArrayLike
+from template_joystick_control.kinematics import inv_rotate
 from template_joystick_control.mapping import JoystickAxes
-from template_joystick_control.tasks import joystick_basin
 from template_joystick_control.topic import Topic
 from typing import Tuple, Literal
+import numpy as np
 import sensor_msgs.msg
 
 
 def joystick_body(
-    joystick_message: sensor_msgs.msg.Joy,
-        axes: JoystickAxes) -> Tuple[ArrayLike, Literal[Topic.joystick]]:
+        joystick: sensor_msgs.msg.Joy,
+        axes: JoystickAxes,
+        heading: float = 0) -> Tuple[ArrayLike, Literal[Topic.joystick]]:
     """
-    sends `[surge, sway, yaw]` commands relative to body regardless of the orientation wrt north
+    sends `[surge, sway, yaw]` commands relative to body
     """
-    return joystick_basin(joystick_message, axes, 0)
+    surge_command = 2 * joystick.axes[axes.LEFT_Y]
+    sway_command = 2 * joystick.axes[axes.LEFT_X]
+    yaw_command = joystick.axes[axes.RIGHT_X]
+
+    tau = inv_rotate(
+        heading) @ np.array([surge_command, sway_command, yaw_command], dtype=float).T
+    return np.array(tau, dtype=float).T, Topic.joystick

--- a/template_joystick_control/template_joystick_control/tasks.py
+++ b/template_joystick_control/template_joystick_control/tasks.py
@@ -49,7 +49,7 @@ def get_actuation_topic_new_task(
         case Task.SIMPLE:
             return joystick_simple(msg, axes), task
         case Task.BODY:
-            return joystick_body(msg, axes), task
+            return joystick_body(msg, axes, 0), task
         case Task.BASIN:
             return joystick_basin(msg, axes, heading), task
         case _:


### PR DESCRIPTION
0 heading is not aligned with the long side of the basin in the lab
however this offset needs to be applied both to basin and body tasks
where one of them is applying it and the other one is reversing it.

To simplify this logic the dependency has been inverted to that the
offset can be set only one.

Update joystick gains
